### PR TITLE
Delete .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.obsidian/


### PR DESCRIPTION
Since this repo has no actual code, a .gitignore file is unnecessary.